### PR TITLE
Ensured that zig builds the firmware before it flashes.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -55,6 +55,7 @@ pub fn build(b: *std.Build) !void {
         tty,
         flash_command,
     });
+    upload.dependOn(b.getInstallStep());
     upload.dependOn(&avrdudeFlash.step);
     avrdudeFlash.step.dependOn(&exe.step);
 


### PR DESCRIPTION
This one lines ensures that the build script runs the default zig build install (default zig build) before it flashes the arduino, when using the zig build flash. This fixes issue: #7 